### PR TITLE
removed at sign from file_get_contents which was in OpauthStrategy.php

### DIFF
--- a/lib/Opauth/OpauthStrategy.php
+++ b/lib/Opauth/OpauthStrategy.php
@@ -399,7 +399,7 @@ class OpauthStrategy{
 			$context = stream_context_create($options);
 		}
 
-		$content = @file_get_contents($url, false, $context);
+		$content = file_get_contents($url, false, $context);
 		$responseHeaders = implode("\r\n", $http_response_header);
 
 		return $content;


### PR DESCRIPTION
removed it so that when OpenSSL was not valid in php, you'll get a error message.
