### PR TITLE
Use classmap autoload scheme in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,8 @@
 		"opauth/twitter": "Allows Twitter authentication"
 	},
 	"autoload": {
-		"psr-0": { 
-			"": "lib/Opauth/",
-			"Opauth": "lib/"
-		}
+		"classmap": [ 
+			"lib/Opauth/"
+		]
 	}
 }


### PR DESCRIPTION
Since Opauth doesn't actually use namespaces, a direct class-to-filepath map might be more appropriate. This is the same approach used by PHPUnit.

This is what the psr-0 scheme generates in `autoload_namespaces.php`:

```
return array(
    '' => array($vendorDir . '/opauth/opauth/lib/Opauth/'),
);
```

Changing it to a classmap generates the following in `autoload_classmap.php`:

```
return array(
    'Opauth' => $baseDir . '/vendor/opauth/opauth/lib/Opauth/Opauth.php',
    'OpauthStrategy' => $baseDir . '/vendor/opauth/opauth/lib/Opauth/OpauthStrategy.php',
)
```

That avoids the fallback. If you're fine with this, I can help update the strategy repos as well.
