### PR TITLE
Enable to overwrite HTTP Header for serverPost

### DIFF
--- a/lib/Opauth/OpauthStrategy.php
+++ b/lib/Opauth/OpauthStrategy.php
@@ -386,8 +386,9 @@ class OpauthStrategy {
 			'content' => $query
 		));
 
-		$stream = array_merge($options, $stream);
-
+        if(isset($options['http'])){
+		    $stream['http'] = array_merge($stream['http'], $options['http']);
+        }
 		return self::httpRequest($url, $stream, $responseHeaders);	
 	}
 	


### PR DESCRIPTION
Hi U-Zyn,

I created new strategy for Yahoo! JAPAN OAuth 2.0 implementation,  
and it needs to set additional HTTP Authorizaton Header for Access Token Request.

```
Authorization: Basic (Base64 encoded Client Credentials)
```

I call serverPost method using options parameter in strategy file.  
[YahoojpStrategy.php](https://github.com/ritou/opauth-yahoojp/blob/master/YahoojpStrategy.php)

```
$options = array(
    'http' => array(
        'header' => "Content-type: application/x-www-form-urlencoded\r\n".
                    "Authorization: Basic ".base64_encode($this->strategy['client_id'] . ':' . $this->strategy['client_secret'])
    )
);
```

However, OpauthStrategy seems to overwrite the $options['http'] with default value by array_merge.  
[Current OpauthStrategy.php](https://github.com/ritou/opauth/blob/74154433b78989e2f6913e7358a826bd77aae8bb/lib/Opauth/OpauthStrategy.php)

```
$stream = array_merge($options, $stream);
```

I changed this logic.
If $options has 'http' array, it overwrites default stream with optional value.

Thanks.
Ryo.
