### PR TITLE
Symfony integration

### DIFF
--- a/lib/Opauth/Opauth.php
+++ b/lib/Opauth/Opauth.php
@@ -50,7 +50,8 @@ class Opauth {
 			'callback_url' => '{path}callback',
 			'callback_transport' => 'session',
 			'debug' => false,
-			
+			'Environment' => '\\OpauthEnvironment',
+
 			/**
 		 	* Security settings
 		 	*/
@@ -73,6 +74,7 @@ class Opauth {
 		if (!class_exists('OpauthStrategy')) {
 			require $this->env['lib_dir'].'OpauthStrategy.php';
 		}
+
 		
 		foreach ($this->env as $key => $value) {
 			$this->env[$key] = OpauthStrategy::envReplace($value, $this->env);
@@ -81,7 +83,8 @@ class Opauth {
 		if ($this->env['security_salt'] == 'LDFmiilYf8Fyw5W10rx4W1KsVrieQCnpBzzpTBWA5vJidQKDx8pMJbmw28R1C4m'){
 			trigger_error('Please change the value of \'security_salt\' to a salt value specific to your application', E_USER_NOTICE);
 		}
-		
+
+		$this->loadEnvironment();
 		$this->loadStrategies();
 		
 		if ($run) {
@@ -179,6 +182,27 @@ class Opauth {
 			}
 		} else {
 			trigger_error('No Opauth strategies defined', E_USER_ERROR);
+		}
+	}
+
+	/**
+	 * Load the environment helper
+	 */
+	private function loadEnvironment() {
+		if (!class_exists('OpauthEnvironment')) {
+			require $this->env['lib_dir'].'OpauthEnvironment.php';
+		}
+
+		if (is_string($this->env['Environment'])) {
+			$uri = $this->env['Environment'];
+			$this->env['Environment'] = new $uri;
+		}
+		elseif (is_callable($this->env['Environment'])) {
+			$this->env['Environment'] = call_user_func($this->env['Environment']);
+		}
+
+		if (!($this->env['Environment'] instanceof OpauthEnvironment)) {
+			trigger_error('Environment must extend OpauthEnvironment', E_USER_ERROR);
 		}
 	}
 		

--- a/lib/Opauth/OpauthEnvironment.php
+++ b/lib/Opauth/OpauthEnvironment.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Opauth Environment
+ * Individual environment are to be extended from this class
+ *
+ * @copyright    Copyright © 2012 U-Zyn Chua (http://uzyn.com)
+ * @link         http://opauth.org
+ * @package      Opauth.Strategy
+ * @license      MIT License
+ */
+
+/**
+ * Opauth Environment
+ * Individual environment are to be extended from this class
+ *
+ * @package            Opauth.Environment
+ */
+class OpauthEnvironment {
+
+	/**
+	 * Redirect to $url with HTTP header (Location: )
+	 *
+	 * @param string $url URL to redirect user to
+	 * @param boolean $exit Whether to call exit() right after redirection
+	 */
+	public function redirect($url, $exit = true) {
+		header("Location: $url");
+
+		if ($exit) {
+			exit();
+		}
+	}
+}

--- a/lib/Opauth/OpauthStrategy.php
+++ b/lib/Opauth/OpauthStrategy.php
@@ -312,16 +312,7 @@ class OpauthStrategy {
 	 * @param boolean $exit Whether to call exit() right after redirection
 	 */
 	public function redirect($url, $exit = true) {
-		if (isset($this->env['symfony_response'])) {
-			$this->env['symfony_response']->headers->set('Location', $url);
-			// Exit is ignored as the framework should send the headers and save the session.
-		}
-		else {
-			header("Location: $url");
-			if ($exit) {
-				exit();
-			}
-		}
+		$this->env['Environment']->redirect($url, $exit);
 	}
 	
 	/**

--- a/tests/Opauth/OpauthStrategyTest.php
+++ b/tests/Opauth/OpauthStrategyTest.php
@@ -9,6 +9,7 @@
  */
 
 require './lib/Opauth/OpauthStrategy.php';
+require './lib/Opauth/OpauthEnvironment.php';
 require './tests/Opauth/OpauthTest.php';
 
 /**
@@ -16,6 +17,9 @@ require './tests/Opauth/OpauthTest.php';
  */
 class OpauthStrategyTest extends OpauthTest {
 
+	/**
+	 * @var OpauthStrategy
+	 */
 	protected $opauthStrategyInstance;
 
 	public function setUp()
@@ -29,6 +33,7 @@ class OpauthStrategyTest extends OpauthTest {
 			'host' => 'host',
 			'callback_url' => 'callback_url',
 			'path' => 'path',
+			'Environment' => new OpauthEnvironment(),
 		));
 	}
 


### PR DESCRIPTION
As symfony has it's own session management and uses the HttpFoundation component to send the response (and the headers). We can't just exit in the middle of the request. 

This PR makes this possible assigning to response object to `symfony_response` in the config. This will be adjusted by Opauth and the controller can return this. 

This will make this package usable for all frameworks using the HttpFoundation component

If you have any remarks/notes to my changes, let me know.
