### PR TITLE
Adding HTTP User-Agent header

### DIFF
--- a/lib/Opauth/OpauthStrategy.php
+++ b/lib/Opauth/OpauthStrategy.php
@@ -409,8 +409,15 @@ class OpauthStrategy {
 	public static function httpRequest($url, $options = null, &$responseHeaders = null) {
 		$context = null;
 		if (!empty($options) && is_array($options)) {
-			$context = stream_context_create($options);
+			if (empty($options['http']['header'])) {
+				$options['http']['header'] = "User-Agent: opauth";
+			} else {
+				$options['http']['header'] . "\r\nUser-Agent: opauth";
+			}
+		} else {
+			$options = array('http' => array('header' => 'User-Agent: opauth'));
 		}
+		$context = stream_context_create($options);
 
 		$content = file_get_contents($url, false, $context);
 		$responseHeaders = implode("\r\n", $http_response_header);


### PR DESCRIPTION
If the PHP configuration option user_agent is empty some provider reject requests with '403 Forbidden'. E.g. GitHub on the reuqest  https://api.github.com/user?access_token=..
The PR adds the header 'User-Agent: opauth' to each request.
