### PR TITLE
Replace the call to self::redirect the call static::redirect

### DIFF
--- a/lib/Opauth/OpauthStrategy.php
+++ b/lib/Opauth/OpauthStrategy.php
@@ -326,7 +326,7 @@ class OpauthStrategy {
 	 * @param boolean $exit Whether to call exit() right after redirection
 	 */
 	public static function clientGet($url, $data = array(), $exit = true) {
-		self::redirect($url.'?'.http_build_query($data, '', '&'), $exit);
+		static::redirect($url.'?'.http_build_query($data, '', '&'), $exit);
 	}
 
 	/**


### PR DESCRIPTION
In order to be in the strategies you can override this method to work strategy. For those times when you need to produce what some action to redirect.
