### PR TITLE
Change default value of $response from null to empty array

### DIFF
--- a/lib/Opauth/Opauth.php
+++ b/lib/Opauth/Opauth.php
@@ -222,7 +222,7 @@ class Opauth {
 	public function callback() {
 		echo "<strong>Note: </strong>Application should set callback URL to application-side for further specific authentication process.\n<br>";
 		
-		$response = null;
+		$response = array();
 		switch($this->env['callback_transport']) {
 			case 'session':
 				if (!session_id()) {


### PR DESCRIPTION
Line 246 produce warning: array_key_exists() expects parameter 2 to be array, null given...
