### PR TITLE
HTTP POST custom header doesn't work

### DIFF
--- a/lib/Opauth/OpauthStrategy.php
+++ b/lib/Opauth/OpauthStrategy.php
@@ -386,7 +386,7 @@ class OpauthStrategy {
 			'content' => $query
 		));
 
-		$stream = array_merge_recursive($options, $stream);
+		$stream = array_replace_recursive($stream, $options);
 
 		return self::httpRequest($url, $stream, $responseHeaders);	
 	}


### PR DESCRIPTION
If I use custom header for HTTP POST request, header is not string. It's array. So I change array_marge_recursive to array_replace_recursive.
