### PR TITLE
Coding style fixes for Opauth\Opauth

### DIFF
--- a/lib/Opauth/Opauth.php
+++ b/lib/Opauth/Opauth.php
@@ -10,7 +10,6 @@
 namespace Opauth;
 
 use Exception;
-use Opauth\AbstractStrategy;
 
 /**
  * Opauth


### PR DESCRIPTION
I've "used" all the Exception class so you don't need to pull them from the global namespace any longer. Also string class names are always from global so the prepended slashes are unneeded and also have weird edge-cases. Also removed all the \Opauth\ prefixes for classes used in the same namespace as they're unneeded.
