### PR TITLE
Bug fix when http-header of options of a serverPost method is set up.

### DIFF
--- a/lib/Opauth/OpauthStrategy.php
+++ b/lib/Opauth/OpauthStrategy.php
@@ -412,6 +412,9 @@ class OpauthStrategy {
 			if (empty($options['http']['header'])) {
 				$options['http']['header'] = "User-Agent: opauth";
 			} else {
+				if (is_array($options['http']['header'])) {
+					$options['http']['header'] = implode("\r\n", $options['http']['header']);
+				}
 				$options['http']['header'] .= "\r\nUser-Agent: opauth";
 			}
 		} else {


### PR DESCRIPTION
Dear Contributor,

It will become arrangement if http-header of options of serverPost is set up. 
Therefore, it added "implode" when http-header was array. 

YahoojpStrategy cannot be used when not fix.

Yours faithfully,
atomita
