### PR TITLE
Set exit to false in the strategy when making a request call

### DIFF
--- a/src/AbstractStrategy.php
+++ b/src/AbstractStrategy.php
@@ -202,7 +202,7 @@ abstract class AbstractStrategy implements StrategyInterface
      * @param array $data Data
      * @param boolean $exit Whether to call exit() right after redirection
      */
-    public function redirect($url, $data = array(), $exit = true)
+    public function redirect($url, $data = array(), $exit = false)
     {
         if ($data) {
             $url .= '?' . http_build_query($data, '', '&');

--- a/src/StrategyInterface.php
+++ b/src/StrategyInterface.php
@@ -43,5 +43,5 @@ interface StrategyInterface
      * @param array $data Data
      * @param boolean $exit Whether to call exit() right after redirection
      */
-    public function redirect($url, $data = array(), $exit = true);
+    public function redirect($url, $data = array(), $exit = false);
 }


### PR DESCRIPTION
Set exit to false by default. When calling it inside of a Controller class, exit() will trigger the call to __destruct() if the class has one. By setting it to false, it is left to the developer to do an explicit exit(), so the program doesn't barf. __destruct() may have certain stuff that you may not want to execute. This fix it. 
