### PR TITLE
similar fix to the one implemented by Symfony Request object

### DIFF
--- a/lib/Opauth/Opauth.php
+++ b/lib/Opauth/Opauth.php
@@ -77,7 +77,7 @@ class Opauth {
 		 * Used mainly as accessors
 		 */
 		$this->env = array_merge(array(
-			'request_uri' => $_SERVER['REQUEST_URI'],
+			'request_uri' => isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '',
 			'complete_path' => $this->config['host'].$this->config['path'],
 			'lib_dir' => dirname(__FILE__).'/',
 			'strategy_dir' => dirname(__FILE__).'/Strategy/'


### PR DESCRIPTION
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Request.php#L1127 to allow for loadbalanced secure connections to have the host for the callback automatically determined, without creating Symfony dependency.  Also set it to not fire notices when referenced from CLI.
