### PR TITLE
Fix opauth parse uri function

### DIFF
--- a/lib/Opauth/Opauth.php
+++ b/lib/Opauth/Opauth.php
@@ -129,7 +129,8 @@ class Opauth {
 	 * Parses Request URI
 	 */
 	private function parseUri() {
-		$this->env['request'] = substr($this->env['request_uri'], strlen($this->env['path']) - 1);
+		$this->env['request'] = substr($this->env['request_uri'],
+			strpos($this->env['request_uri'], $this->env['path']) + strlen($this->env['path']) - 1);
 
 		if (preg_match_all('/\/([A-Za-z0-9-_]+)/', $this->env['request'], $matches)) {
 			foreach ($matches[1] as $match) {


### PR DESCRIPTION
The parseUri function takes the URI of the request and extracts the
paramters. The request string starts immediately after the web path.

The current implementation does not consider, that the URI can start
with a port definition. In this case the extracted request is not
correct.

By searching the web path and let the paramter string start after that,
the URI is parsed correctly.